### PR TITLE
Find brother node

### DIFF
--- a/src/main/java/programminglife/gui/controller/GuiController.java
+++ b/src/main/java/programminglife/gui/controller/GuiController.java
@@ -353,7 +353,7 @@ public class GuiController implements Observer {
         btnDraw.setOnAction(e -> this.draw());
 
         btnDrawRandom.setOnAction(event -> {
-            int randomNodeID = (new Random()).nextInt(this.graphController.getGraph().size());
+            int randomNodeID = (new Random()).nextInt(this.graphController.getGraph().size() - 1) + 1;
             txtCenterNode.setText(Integer.toString(randomNodeID));
             this.draw();
         });

--- a/src/main/java/programminglife/model/drawing/SubGraph.java
+++ b/src/main/java/programminglife/model/drawing/SubGraph.java
@@ -54,6 +54,7 @@ public class SubGraph {
 
         // TODO: also go from all parents to children within 2*radius + 1; and vice-versa from children.
         this.nodes = findParents(centerNode, radius);
+
         this.nodes.putAll(findChildren(centerNode, radius));
         if (!this.nodes.containsKey(centerNode.getNode())) {
             this.nodes.put(centerNode.getNode(), centerNode);
@@ -115,6 +116,14 @@ public class SubGraph {
                 found.put(parent, new DrawableNode(parent));
                 findParents(found, found.get(parent), radius);
             }
+
+        }
+        //Also check the childeren if one of the nodes has not been added yet.
+        for (Node child : node.getChildren()) {
+            if (!found.containsKey(child)) {
+                found.put(child, new DrawableNode(child));
+                findChildren(found, found.get(child), radius);
+            }
         }
     }
 
@@ -141,6 +150,11 @@ public class SubGraph {
      */
     private LinkedHashMap<Node, DrawableNode> findChildren(Set<DrawableNode> nodes, int radius) {
         LinkedHashMap<Node, DrawableNode> found = new LinkedHashMap<>();
+
+        //Put all node that are already found by findparents into the find.
+        for (DrawableNode node: nodes) {
+           found.put(node.getNode(), node);
+        }
         for (DrawableNode node : nodes) {
             findChildren(found, node, radius);
         }
@@ -169,6 +183,14 @@ public class SubGraph {
                 found.put(child, new DrawableNode(child));
                 findChildren(found, found.get(child), radius);
             }
+        }
+
+        for (Node parent : node.getParents()) {
+            if (!found.containsKey(parent)) {
+                found.put(parent, new DrawableNode(parent));
+                findParents(found, found.get(parent), radius);
+            }
+
         }
     }
 

--- a/src/main/java/programminglife/model/drawing/SubGraph.java
+++ b/src/main/java/programminglife/model/drawing/SubGraph.java
@@ -108,6 +108,9 @@ public class SubGraph {
         // assuming radius 3, if you find the nodes in the order 0, 1, 2, 3,
         // you cannot skip 3 as that would then miss 4 (which is also within radius 3, via 0-1-3-4)
         //Also check the childeren if one of the nodes has not been added yet.
+        if (this.radius <= 0) {
+            return;
+        }
         for (Node child : node.getChildren()) {
             if (!found.containsKey(child)) {
                 found.put(child, new DrawableNode(child));
@@ -175,6 +178,9 @@ public class SubGraph {
         //                                            \_/
         // assuming radius 3, if you find the nodes in the order 0, 1, 2, 3,
         // you cannot skip 3 as that would then miss 4 (which is also within radius 3, via 0-1-3-4)
+        if (this.radius <= 0) {
+            return;
+        }
         for (Node parent : node.getParents()) {
             if (!found.containsKey(parent)) {
                 found.put(parent, new DrawableNode(parent));

--- a/src/main/java/programminglife/model/drawing/SubGraph.java
+++ b/src/main/java/programminglife/model/drawing/SubGraph.java
@@ -107,6 +107,13 @@ public class SubGraph {
         //                                            \_/
         // assuming radius 3, if you find the nodes in the order 0, 1, 2, 3,
         // you cannot skip 3 as that would then miss 4 (which is also within radius 3, via 0-1-3-4)
+        //Also check the childeren if one of the nodes has not been added yet.
+        for (Node child : node.getChildren()) {
+            if (!found.containsKey(child)) {
+                found.put(child, new DrawableNode(child));
+                findChildren(found, found.get(child), 2 * this.radius - radius - 1);
+            }
+        }
         if (radius <= 0) {
             return;
         }
@@ -118,13 +125,7 @@ public class SubGraph {
             }
 
         }
-        //Also check the childeren if one of the nodes has not been added yet.
-        for (Node child : node.getChildren()) {
-            if (!found.containsKey(child)) {
-                found.put(child, new DrawableNode(child));
-                findChildren(found, found.get(child), 2 * this.radius - radius);
-            }
-        }
+
     }
 
     /**
@@ -174,6 +175,13 @@ public class SubGraph {
         //                                            \_/
         // assuming radius 3, if you find the nodes in the order 0, 1, 2, 3,
         // you cannot skip 3 as that would then miss 4 (which is also within radius 3, via 0-1-3-4)
+        for (Node parent : node.getParents()) {
+            if (!found.containsKey(parent)) {
+                found.put(parent, new DrawableNode(parent));
+                findParents(found, found.get(parent), 2 * this.radius - radius - 1);
+            }
+
+        }
         if (radius <= 0) {
             return;
         }
@@ -185,13 +193,7 @@ public class SubGraph {
             }
         }
 
-        for (Node parent : node.getParents()) {
-            if (!found.containsKey(parent)) {
-                found.put(parent, new DrawableNode(parent));
-                findParents(found, found.get(parent), 2 * this.radius - radius);
-            }
 
-        }
     }
 
     /**

--- a/src/main/java/programminglife/model/drawing/SubGraph.java
+++ b/src/main/java/programminglife/model/drawing/SubGraph.java
@@ -122,7 +122,7 @@ public class SubGraph {
         for (Node child : node.getChildren()) {
             if (!found.containsKey(child)) {
                 found.put(child, new DrawableNode(child));
-                findChildren(found, found.get(child), radius);
+                findChildren(found, found.get(child), 2 * this.radius - radius);
             }
         }
     }
@@ -188,7 +188,7 @@ public class SubGraph {
         for (Node parent : node.getParents()) {
             if (!found.containsKey(parent)) {
                 found.put(parent, new DrawableNode(parent));
-                findParents(found, found.get(parent), radius);
+                findParents(found, found.get(parent), 2 * this.radius - radius);
             }
 
         }

--- a/src/test/java/programminglife/model/drawing/SubGraphTest.java
+++ b/src/test/java/programminglife/model/drawing/SubGraphTest.java
@@ -60,7 +60,7 @@ public class SubGraphTest {
     public void testConstructorRadius1() throws Exception {
         SubGraph sg = new SubGraph(centerNode, 1);
         Set<DrawableNode> nodes = new LinkedHashSet<>(sg.getNodes().values());
-        assertEquals(3, nodes.size());
+        assertEquals(4, nodes.size());
         assertTrue(nodes.contains(centerNode));
         assertTrue(nodes.containsAll(sg.getChildren(centerNode)));
         assertTrue(nodes.containsAll(sg.getParents(centerNode)));

--- a/src/test/java/programminglife/model/drawing/SubGraphTest.java
+++ b/src/test/java/programminglife/model/drawing/SubGraphTest.java
@@ -71,12 +71,12 @@ public class SubGraphTest {
         SubGraph sg = new SubGraph(centerNode, 4);
 
         Set<DrawableNode> expected = new HashSet<>();
-        for (Integer id : new int[] {1, 2, 4, 5, 6, 7, 8}) {
+        for (Integer id : new int[] {1, 2, 3, 4, 5, 6, 7, 8}) {
             expected.add(new DrawableNode(new Segment(graph, id)));
         }
 
         Set<DrawableNode> actual = new LinkedHashSet<>(sg.getNodes().values());
-        assertEquals(7, actual.size());
+        assertEquals(8, actual.size());
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
In this branch I have fixed:
- The chance of finding the brother and sister nodes is significantly increased. This is done by checking for every new node found if the parents AND the children are already found. 
- The random.NextInt() no longer has the possibility to return 0. 

Took about 1 hour to do. 

closes #200 .